### PR TITLE
Update build.sh

### DIFF
--- a/opensim/build.sh
+++ b/opensim/build.sh
@@ -20,11 +20,21 @@ cd ..
 
 # cp -r $PREFIX/simbody/libexec/simbody/* $PREFIX/bin/
 
+
 if [ "$(uname)" == "Darwin" ]; then
    SWIG_DIR_SPEC=/usr/local/Cellar/swig/4.0.2
+   SWIG_EXE_SPEC=~/swig/bin/swig
 else
-   SWIG_DIR_SPEC=~/swig/share/swig 
+   # Check if swig has been installed using package manager.
+   if [ -d "/usr/share/swig4.0" ]; then
+      SWIG_DIR_SPEC=/usr/share/swig4.0
+      SWIG_EXE_SPEC=/usr/bin/swig
+   else
+      SWIG_DIR_SPEC=~/swig/share/swig 
+      SWIG_EXE_SPEC=~/swig/bin/swig
+   fi
 fi
+
 # TODO: Tests are missing!
 mkdir opensim_build
 cd opensim_build
@@ -36,7 +46,7 @@ cmake ../ \
       -DCMAKE_OSX_SYSROOT=${CONDA_BUILD_SYSROOT} \
       -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 \
       -DSWIG_DIR=${SWIG_DIR_SPEC} \
-      -DSWIG_EXECUTABLE=~/swig/bin/swig \
+      -DSWIG_EXECUTABLE=${SWIG_EXE_SPEC} \
       -DBUILD_PYTHON_WRAPPING=ON \
       -DOPENSIM_DISABLE_LOG_FILE=ON \
       -DOPENSIM_C3D_PARSER=ezc3d \


### PR DESCRIPTION
In Ubuntu 22.04, you can install swig 4.0.2 using the package manager, but the current approach is only detecting swig installed in ~/swig. With these changes, it can work following both approaches.

### Brief summary of changes

I've modified the script in a way that first checks if swig 4.0.2 has been installed using the package manager. If so, it uses it. If it has not been installed using the package manager, it follows the same approach as before.

### Testing I've completed

This has passed CI in my fork (which proves it works if swig is installed manually inside of ~/swig) and in my local computer (which proves it works using the swig installed using the package manager).

### Looking for feedback on...

Is the SWIG_EXE_SPEC path correct in mac? The current path assigned is the one established by default before my changes.
