### PR TITLE
Update meta.yaml

### DIFF
--- a/opensim/meta.yaml
+++ b/opensim/meta.yaml
@@ -15,7 +15,7 @@ build:
     # NOTE : This is needed to ensure the paths to Simbody's binaries, like
     # simbody-visualizer, are corrected.
     detect_binary_files_with_prefix: true
-    string: py{{ CONDA_PY }}np{{ CONDA_NPY }}
+
 requirements:
     host:
         - openblas # [not win]
@@ -32,8 +32,8 @@ requirements:
         - make # [not win]
 
     run:
-        - python
-        - numpy
+        - python {{ CONDA_PY }}
+        - numpy {{ CONDA_NPY }}
         - freeglut # [win]
         - openblas # [not win]
 


### PR DESCRIPTION
Updating meta.yml for conda build.  Related to: https://github.com/opensim-org/opensim-core/issues/3273

Recommended [here](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#run) that the numpy version should be specified under the requirements/run section. This is where we specify the requirements for the runtime environment. They also specified something about specifying `--numpy` with `conda-build` if using this syntax - I haven't built recipes before so I'll leave that part for someone else that knows the usual syntax/where/when to call this. 

I also deleted the build string because I believe that this should be done automatically if you specify a version for requirements/run (but Im not positive on this one). I think that this string should be built by conda-build to have a unique hash that goes after the python version to specify the dependencies etc. and this is how different requirements (e.g., numpy) are specified.